### PR TITLE
Update transients-manager.php

### DIFF
--- a/transients-manager.php
+++ b/transients-manager.php
@@ -357,7 +357,7 @@ class PW_Transients_Manager {
 
 			$value = 'array';
 
-		} elseif( is_object( $value ) ) {
+		} elseif( gettype( $value ) == 'object' ) {
 
 			$value = 'object';
 


### PR DESCRIPTION
The plugin fails in case an object whose class definition is not present is being fed to `<get_transient_value>` which is using `<is_object>` to detect objects that are not arrays. This happens for example with the [Google Analytics Dashboard for WP](https://wordpress.org/plugins/google-analytics-dashboard-for-wp/) installed.