### PR TITLE
Added $action parameter to process_actions()

### DIFF
--- a/transients-manager.php
+++ b/transients-manager.php
@@ -460,13 +460,15 @@ class PW_Transients_Manager {
 	 * @return  void
 	 * @since   1.0
 	*/
-	public function process_actions() {
+	public function process_actions( $action = false ) {
 
-		if( empty( $_REQUEST['action'] ) ) {
+		$action = ( ! empty( $_REQUEST['action'] ) )? $_REQUEST['action'] : $action;
+		
+		if( empty( $action ) ) {
 			return;
 		}
 
-		if( empty( $_REQUEST['transient'] ) && ( 'suspend_transients' !== $_REQUEST['action'] && 'unsuspend_transients' !== $_REQUEST['action'] ) ) {
+		if( empty( $_REQUEST['transient'] ) && ( 'suspend_transients' !== $action && 'unsuspend_transients' !== $action ) ) {
 			return;
 		}
 
@@ -478,7 +480,7 @@ class PW_Transients_Manager {
 			return;
 		}
 
-		if( 'suspend_transients' !== $_REQUEST['action'] && 'unsuspend_transients' !== $_REQUEST['action'] ) {
+		if( 'suspend_transients' !== $action && 'unsuspend_transients' !== $action ) {
 
 			$search    = ! empty( $_REQUEST['s'] ) ? urlencode( $_REQUEST['s'] ) : '';
 			$transient = $_REQUEST['transient'];
@@ -486,7 +488,7 @@ class PW_Transients_Manager {
 
 		}
 
-		switch( $_REQUEST['action'] ) {
+		switch( $action ) {
 
 			case 'delete_transient' :
 				$this->delete_transient( $transient, $site_wide );


### PR DESCRIPTION
Added a parameter to the `process_actions()` function so that the functionality can be used outside of the UI interface. For example, it can be called from the `save_post` action to delete transients with expirations (to clear cached queries, for instance).

Note: I'm don't generally do pull requests, so I hope I'm doing this right, heh.