### PR TITLE
Changed hook where textdomain is loaded

### DIFF
--- a/src/TransientsManager.php
+++ b/src/TransientsManager.php
@@ -119,7 +119,7 @@ class TransientsManager {
      * @since 2.0
      */
     public function init() {
-        add_action( 'plugins_loaded',    array( $this, 'text_domain' ) );
+        add_action( 'after_setup_theme', array( $this, 'text_domain' ) );
         add_action( 'admin_init',        array( $this, 'set_vars' ) );
         add_action( 'admin_init',        array( $this, 'process_actions' ) );
         add_action( 'admin_menu',        array( $this, 'tools_link' ) );


### PR DESCRIPTION
Ticket: https://developer.wordpress.org/reference/functions/load_plugin_textdomain/
Slack: https://awesomemotive.slack.com/archives/C04GJTUBRR6/p1728474519371679